### PR TITLE
add `copy_text_to_clipboard` method

### DIFF
--- a/lib/net/vnc.rb
+++ b/lib/net/vnc.rb
@@ -324,6 +324,16 @@ module Net
       end
     end
 
+    def copy_text_to_clipboard text
+      text = text.to_s.gsub(/\R/, "\n") # eol of ClientCutText's text is LF
+      byte_size = text.to_s.bytes.size
+      packet = 0.chr * (8 + byte_size)
+      packet[0] = 6.chr # message-type: 6 (ClientCutText)
+      packet[4, 4] = [byte_size].pack('N') # length
+      packet[8, byte_size] = text
+      socket.write(packet)
+    end
+
     private
 
     def read_packet type


### PR DESCRIPTION
RFB プロトコルの `ClientCutText` メッセージを送り、クリップボードにテキストを挿入するメソッドを追加しました。